### PR TITLE
Include readme on target package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@joebowbeer/regsync",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joebowbeer/regsync",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Publish package versions from one registry into another",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,25 +25,16 @@ export async function sync(name: string, from: Record<string, string>, to: Recor
     return 0
   }
 
-  // Always publish latest repository info
-  const latestRepository = srcPackument.versions[srcPackument['dist-tags'].latest].repository
-  console.debug('Latest repository', latestRepository)
-
   for (const version of missing) {
     const spec = name + '@' + version
     console.log('Reading %s from %s', spec, from.registry)
 
-    const manifest = srcPackument.versions[version]
-    if (!manifest.readme) {
-      manifest.readme = srcPackument.readme
-    }
+    const manifest = prepareManifest(srcPackument, version)
     console.debug('Dist', manifest.dist)
 
     //const tarball = await getTarball(spec, srcOptions)
     const tarball = await fetchTarball(manifest.dist, from.token)
     console.debug('Tarball length', tarball.length)
-
-    prepareManifest(manifest, latestRepository)
 
     console.log('Publishing %s to %s', spec, to.registry)
     await publish(manifest, tarball, dstOptions, dryRun)

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,9 @@ export async function sync(name: string, from: Record<string, string>, to: Recor
     console.log('Reading %s from %s', spec, from.registry)
 
     const manifest = srcPackument.versions[version]
+    if (!manifest.readme) {
+      manifest.readme = srcPackument.readme
+    }
     console.debug('Dist', manifest.dist)
 
     //const tarball = await getTarball(spec, srcOptions)

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -37,25 +37,87 @@ test('scopedOptions without scope or token', () => {
 })
 
 test('prepareManifest removes publishConfig and updates repository', () => {
-  const manifest = {
-    dist: {},
-    publishConfig: 'myPublishConfig',
-    repository: 'oldRepository'
+  const packument = {
+    'dist-tags': {
+      latest: '1.0.0'
+    },
+    versions: {
+      '0.0.1': {
+        publishConfig: 'myPublishConfig',
+        repository: 'oldRepository'
+      },
+      '1.0.0': {
+        publishConfig: 'myPublishConfig',
+        repository: 'newRepository'
+      }
+    }
   }
-  prepareManifest(manifest, 'newRepository')
+
+  const manifest = prepareManifest(packument, '0.0.1')
   expect(manifest.publishConfig).toBeUndefined
   expect(manifest.repository).toEqual('newRepository')
 })
 
 test('prepareManifest retains non-string values from dist', () => {
-  const manifest = {
-    dist: {
-      fileCount: 123,
-      integrity: 'myIntegrity',
-      unpackedSize: 456
+  const packument = {
+    'dist-tags': {
+      latest: '1.0.0'
+    },
+    versions: {
+      '1.0.0': {
+        dist: {
+          fileCount: 123,
+          integrity: 'myIntegrity',
+          unpackedSize: 456
+        },
+        publishConfig: 'myPublishConfig',
+        repository: 'newRepository'
+      }
     }
   }
-  const expected = {...manifest.dist}
-  prepareManifest(manifest, 'myRepository')
+  const expected = {...packument.versions['1.0.0'].dist}
+  const manifest = prepareManifest(packument, '1.0.0')
   expect(manifest.dist).toEqual(expected)
+})
+
+test('prepareManifest includes readme/readmeFilename on latest version', () => {
+  const packument = {
+    'dist-tags': {
+      latest: '1.0.0'
+    },
+    versions: {
+      '1.0.0': {
+        dist: {},
+        publishConfig: 'myPublishConfig'
+      }
+    },
+    readme: '# readme',
+    readmeFilename: 'README.md'
+  }
+  const manifest = prepareManifest(packument, '1.0.0')
+  expect(manifest.readme).toEqual('# readme')
+  expect(manifest.readmeFilename).toEqual('README.md')
+})
+
+test('prepareManifest ignores readme/readmeFilename if not the latest version', () => {
+  const packument = {
+    'dist-tags': {
+      latest: '1.0.0'
+    },
+    versions: {
+      '0.0.1': {
+        dist: {},
+        publishConfig: 'myPublishConfig'
+      },
+      '1.0.0': {
+        dist: {},
+        publishConfig: 'myPublishConfig'
+      }
+    },
+    readme: '# readme',
+    readmeFilename: 'README.md'
+  }
+  const manifest = prepareManifest(packument, '0.0.1')
+  expect(manifest.readme).toBeUndefined
+  expect(manifest.readmeFilename).toBeUndefined
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,11 +68,23 @@ export async function fetchTarball(dist: ManifestDist, token?: string) {
 }
 
 // Prepare manifest before publishing to target
-export function prepareManifest(manifest: Record<string, any>, latestRepository) {
+export function prepareManifest(packument: Record<string, any>, version: string): Record<string, any> {
+  const manifest = packument.versions[version]
+  const latestVersion = packument['dist-tags'].latest
+
   // Remove source registry
   delete manifest.publishConfig
-  // Update repository
-  manifest.repository = latestRepository
+
+  // Always publish latest repository info
+  manifest.repository = packument.versions[latestVersion].repository
+
+  // Ensure we include the readme on the latest version
+  if (!manifest.readme && version === latestVersion) {
+    manifest.readme = packument.readme
+    manifest.readmeFilename = packument.readmeFilename
+  }
+
+  return manifest
 }
 
 export async function publish(


### PR DESCRIPTION
This tool is awesome, but I noticed it wasn't bringing the readme documents into GitHub packages. 

This change copies the readme from srcPackument to the target manifest, if one didn't exist already.

I thought someone else might find this useful :) 